### PR TITLE
Fix for to_csv()

### DIFF
--- a/knackpy/__init__.py
+++ b/knackpy/__init__.py
@@ -492,7 +492,7 @@ class Knack(object):
         _______
         None
         '''
-        with open(filename, 'w', newline='\n') as fout:
+        with open(filename, 'wb') as fout:
             self.fieldnames.sort()
 
             writer = csv.DictWriter(fout, fieldnames=self.fieldnames, delimiter=delimiter)


### PR DESCRIPTION
"TypeError: 'newline' is an invalid keyword argument for this function"